### PR TITLE
chore: fix phpunit.yml

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -20,4 +20,4 @@ on:
 
 jobs:
   phpunit:
-    uses: codeigniter4/.github/.github/workflows/phpunit.yml@main
+    uses: codeigniter4/.github/.github/workflows/phpunit-no-db.yml@main

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -37,7 +37,7 @@
 	</coverage>
 
 	<testsuites>
-		<testsuite name="CacheIntegration">
+		<testsuite name="main">
 			<directory>./tests</directory>
 		</testsuite>
 	</testsuites>


### PR DESCRIPTION
**Description**
Follow-up #16

- Fix the workflow does not work because of wrong testsuite name. 
- Use phpunit-no-db.yml.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [] Conforms to style guide
