### PR TITLE
chore: update Psalm config

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <psalm
+    phpVersion="8.1"
     errorLevel="7"
     resolveFromConfigFile="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -7,6 +8,8 @@
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
     autoloader="psalm_autoload.php"
     cacheDirectory="build/psalm/"
+    findUnusedBaselineEntry="false"
+    findUnusedCode="false"
 >
     <projectFiles>
         <directory name="src/" />

--- a/psalm_autoload.php
+++ b/psalm_autoload.php
@@ -10,6 +10,10 @@ $helperDirs = [
 
 foreach ($helperDirs as $dir) {
     $dir = __DIR__ . '/' . $dir;
+    if (! is_dir($dir)) {
+        continue;
+    }
+
     chdir($dir);
 
     foreach (glob('*_helper.php') as $filename) {
@@ -18,3 +22,5 @@ foreach ($helperDirs as $dir) {
         require_once $filePath;
     }
 }
+
+chdir(__DIR__);

--- a/src/Pool.php
+++ b/src/Pool.php
@@ -79,8 +79,8 @@ final class Pool implements CacheItemPoolInterface
     /**
      * Returns a traversable set of cache items.
      *
-     * @param string[] $keys
-     *                       An indexed array of keys of items to retrieve.
+     * @param list<string> $keys
+     *                           An indexed array of keys of items to retrieve.
      *
      * @throws CacheArgumentException
      *                                If any of the keys in $keys are not a legal value a \Psr\Cache\InvalidArgumentException
@@ -178,8 +178,8 @@ final class Pool implements CacheItemPoolInterface
     /**
      * Removes multiple items from the pool.
      *
-     * @param string[] $keys
-     *                       An array of keys that should be removed from the pool.
+     * @param list<string> $keys
+     *                           An array of keys that should be removed from the pool.
      *
      * @throws CacheArgumentException
      *                                If any of the keys in $keys are not a legal value a \Psr\Cache\InvalidArgumentException


### PR DESCRIPTION
**Description**
- update Psalm config
- update coding style

```
Run vendor/bin/psalm
Warning: "findUnusedBaselineEntry" will default to "true" in Psalm 6. You should explicitly enable or disable this setting.
Warning: "findUnusedCode" will default to "true" in Psalm 6. You should explicitly enable or disable this setting.
Warning: "findUnusedBaselineEntry" will default to "true" in Psalm 6. You should explicitly enable or disable this setting.
Warning: "findUnusedCode" will default to "true" in Psalm 6. You should explicitly enable or disable this setting.
Target PHP version: 7.4 (inferred from composer.json).
Scanning files...
Analyzing files...

░░EEE░░░
Error: src/Pool.php:230:20: UndefinedFunction: Function CodeIgniter\Psr\Cache\config does not exist (see https://psalm.dev/021)
Error: src/SimpleCache.php:67:20: UndefinedFunction: Function CodeIgniter\Psr\Cache\config does not exist (see https://psalm.dev/021)
Error: src/SupportTrait.php:44:30: UndefinedFunction: Function CodeIgniter\Psr\Cache\service does not exist (see https://psalm.dev/021)
Error: src/SupportTrait.php:46:30: UndefinedFunction: Function CodeIgniter\Psr\Cache\service does not exist (see https://psalm.dev/021)
------------------------------
4 errors found
------------------------------
19 other issues found.
You can display them with --show-info=true
------------------------------
Psalm can automatically fix 8 of these issues.
Run Psalm again with 
--alter --issues=MissingReturnType --dry-run
to see what it can fix.
------------------------------

Checks took 4.40 seconds and used 292.190MB of memory
Psalm was able to infer types for 93.8511% of the codebase
Error: Process completed with exit code 2.
```
https://github.com/codeigniter4/cache/actions/runs/9032646473/job/24821235799

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
