### PR TITLE
chore: fix PHPUnit version to ^9.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
         "cache/integration-tests": "^0.17.0",
         "codeigniter4/devkit": "^1.0",
         "codeigniter4/framework": "^4.1",
+        "phpunit/phpunit": "^9.6",
         "rector/rector": "1.1.0"
     },
     "provide": {


### PR DESCRIPTION
**Description**
```
Run vendor/bin/phpunit --verbose --coverage-text --testsuite main
PHPUnit 10.5.20 by Sebastian Bergmann and contributors.

Unknown option "--verbose"
Error: Process completed with exit code 2.
```
https://github.com/codeigniter4/cache/actions/runs/9207748908/job/25328475291

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
